### PR TITLE
Stale cache fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asu_professor_view",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "npx tsx src/rmp-api.ts",

--- a/src/Background/background.ts
+++ b/src/Background/background.ts
@@ -1,9 +1,12 @@
 import { RateMyProfessor } from "rate-my-professor-api-ts"
 
 const storage = chrome.storage.local;
-const CACHE_DURATION = 5 * 60 * 1000; // This is 5 mins in ms
-const CLEANUP_INTERVAL = 5 // 5 my noots
+const CACHE_DURATION = 10 * 60 * 1000; // This is 10 mins in ms
+const CLEANUP_INTERVAL = 10 // 10 minutes
 const CLEANUP_ALARM_NAME = 'cleanupExpiredEntries';
+const CACHE_CLEAR_MESSAGE = "clearProfessorCache";
+const CACHE_KEY_PREFIX = "professorCache_";
+
 const ASU_CAMPUSES = [
   "Arizona State University",
   "Arizona State University - Polytechnic Campus",
@@ -204,7 +207,7 @@ function validateProfessor(originalName: string, professorData: any, searchedNam
 }
 
 async function getRateMyProfessorData(professorName: string) {
-  const cacheKey = professorName.toLowerCase().trim();
+  const cacheKey = `${CACHE_KEY_PREFIX}${professorName.toLowerCase().trim()}`;
   const cachedData = await getWithExpiration(cacheKey);
 
   if (cachedData !== null) {
@@ -223,25 +226,25 @@ async function getRateMyProfessorData(professorName: string) {
     return result;
 
   } catch (error) {
-    // Log the error but don't crash the extension
     console.warn(`IMPORTANT: Could not find professor "${professorName}":`, error instanceof Error ? error.message : error);
-    
-    // Cache the failure to avoid repeated failed requests
+
     const failureResult = {
       error: true,
       message: `Professor "${professorName}" not found`,
       searchedName: professorName,
       timestamp: Date.now()
     };
-    
-    try {
-      await setWithExpiration(cacheKey, failureResult, CACHE_DURATION);
-    }
-    catch (storageError) {
-      console.warn(`Cache write for failure result failed: `, storageError);
-    }
-    
+
     return failureResult;
+  }
+}
+
+async function clearProfessorCache() {
+  const all = await chrome.storage.local.get(null);
+  const keysToRemove = Object.keys(all).filter((key) => key.startsWith(CACHE_KEY_PREFIX));
+
+  if (keysToRemove.length > 0) {
+    await chrome.storage.local.remove(keysToRemove);
   }
 }
 
@@ -256,7 +259,7 @@ chrome.runtime.onMessage.addListener(
             sendResponse({ 
               success: false, 
               error: professor_info.message,
-              cached: true 
+              cached: false 
             });
           } else {
             sendResponse({ success: true, data: professor_info });
@@ -272,6 +275,20 @@ chrome.runtime.onMessage.addListener(
       })();
 
       return true; // Keep the message channel open for async response
+    }
+    else if (request.type === CACHE_CLEAR_MESSAGE) {
+      (async () => {
+        try {
+          await clearProfessorCache();
+          sendResponse({ success: true });
+        }
+        catch (error) {
+          console.error("Error clearing professor cache:", error);
+          sendResponse({ success: false, error: error instanceof Error ? error.message : "Unknown error"});
+        }
+      })();
+
+      return true;
     }
   }
 );

--- a/src/Background/background.ts
+++ b/src/Background/background.ts
@@ -5,8 +5,6 @@ const CACHE_DURATION = 10 * 60 * 1000; // This is 10 mins in ms
 const CLEANUP_INTERVAL = 10 // 10 minutes
 const CLEANUP_ALARM_NAME = 'cleanupExpiredEntries';
 const CACHE_CLEAR_MESSAGE = "clearProfessorCache";
-const CACHE_KEY_PREFIX = "professorCache_";
-
 const ASU_CAMPUSES = [
   "Arizona State University",
   "Arizona State University - Polytechnic Campus",
@@ -207,7 +205,7 @@ function validateProfessor(originalName: string, professorData: any, searchedNam
 }
 
 async function getRateMyProfessorData(professorName: string) {
-  const cacheKey = `${CACHE_KEY_PREFIX}${professorName.toLowerCase().trim()}`;
+  const cacheKey = professorName.toLowerCase().trim();
   const cachedData = await getWithExpiration(cacheKey);
 
   if (cachedData !== null) {
@@ -240,12 +238,7 @@ async function getRateMyProfessorData(professorName: string) {
 }
 
 async function clearProfessorCache() {
-  const all = await chrome.storage.local.get(null);
-  const keysToRemove = Object.keys(all).filter((key) => key.startsWith(CACHE_KEY_PREFIX));
-
-  if (keysToRemove.length > 0) {
-    await chrome.storage.local.remove(keysToRemove);
-  }
+  await storage.clear();
 }
 
 chrome.runtime.onMessage.addListener(

--- a/src/Popup/popup.html
+++ b/src/Popup/popup.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title></title>
+    <script src="popup.js" defer></script>
     <style>
       @import url("https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,100..900;1,100..900&display=swap");
 
@@ -26,6 +27,7 @@
         font-weight: bold;
         width: 200px;
         box-sizing: border-box;
+        margin-bottom: 4px;
       }
 
       .link-button:hover {
@@ -67,6 +69,20 @@
         </svg>
         &nbsp; Settings
       </a>
+      <button class="link-button" id="clear-cache-button" type="button">
+        <svg
+          class="icon"
+          xmlns="https://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="white"
+          aria-hidden="true"
+        >
+          <path
+            d="M24 13.616v-3.232c-1.651-.587-2.694-.752-3.219-2.019v-.001c-.527-1.271.1-2.134.847-3.707l-2.285-2.285c-1.561.742-2.433 1.375-3.707.847h-.001c-1.269-.526-1.435-1.576-2.019-3.219h-3.232c-.582 1.635-.749 2.692-2.019 3.219h-.001c-1.271.528-2.132-.098-3.707-.847l-2.285 2.285c.745 1.568 1.375 2.434.847 3.707-.527 1.271-1.584 1.438-3.219 2.02v3.232c1.632.58 2.692.749 3.219 2.019.53 1.282-.114 2.166-.847 3.707l2.285 2.286c1.562-.743 2.434-1.375 3.707-.847h.001c1.27.526 1.436 1.579 2.019 3.219h3.232c.582-1.636.75-2.69 2.027-3.222h.001c1.262-.524 2.12.101 3.698.851l2.285-2.286c-.744-1.563-1.375-2.433-.848-3.706.527-1.271 1.588-1.44 3.221-2.021zm-12 2.384c-2.209 0-4-1.791-4-4s1.791-4 4-4 4 1.791 4 4-1.791 4-4 4z"
+          />
+        </svg>
+        &nbsp; Clear Cache
+      </button>
     </div>
   </body>
 </html>

--- a/src/Popup/popup.js
+++ b/src/Popup/popup.js
@@ -9,8 +9,12 @@ if (clearCacheButton) {
             }
 
             if (response?.success) {
-                alert("Professor cache cleared successfully.");
+                clearCacheButton.textContent = "Cache Cleared!";
+                setTimeout(() => {
+                    clearCacheButton.textContent = "Clear Professor Cache";
+                }, 2000);
             } else {
+                clearCacheButton.textContent = "Failed to Clear!";
                 console.error("Failed to clear professor cache via popup button:", response?.error);
             }
         });

--- a/src/Popup/popup.js
+++ b/src/Popup/popup.js
@@ -1,0 +1,18 @@
+const clearCacheButton = document.getElementById("clear-cache-button");
+
+if (clearCacheButton) {
+    clearCacheButton.addEventListener("click", () => {
+        chrome.runtime.sendMessage({ type: "clearProfessorCache" }, (response) => {
+            if (chrome.runtime.lastError) {
+                console.error("Failed to clear professor cache via popup button:", chrome.runtime.lastError.message);
+                return;
+            }
+
+            if (response?.success) {
+                alert("Professor cache cleared successfully.");
+            } else {
+                console.error("Failed to clear professor cache via popup button:", response?.error);
+            }
+        });
+    });
+}

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ASU ProfessorView",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Rate My Professor Plugin for ASU Class Search. See professor ratings directly in ASU Class Search.",
     "author": "n.joshuamanigault@gmail.com",
     "homepage_url": "https://github.com/joshuamanigault/ASUProfessorView",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ASU ProfessorView",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Rate My Professor Plugin for ASU Class Search. See professor ratings directly in ASU Class Search.",
     "author": "n.joshuamanigault@gmail.com",
     "homepage_url": "https://github.com/joshuamanigault/ASUProfessorView",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         copyFileSync("src/Options/options.css", `${outDir}/options.css`);
         copyFileSync("src/Content/content.styles.css", `${outDir}/content.styles.css`);
         copyFileSync("src/Content/templates.js", `${outDir}/templates.js`);
+        copyFileSync("src/Popup/popup.js", `${outDir}/popup.js`);
       },
     },
   ],


### PR DESCRIPTION
This pull request adds a new feature to allow users to clear the cached professor data from the extension popup, improves cache management, and makes minor UI and configuration updates. The most important changes are grouped below:

**New Feature: Clear Professor Cache from Popup**
* Added a "Clear Cache" button to the popup (`popup.html`) and implemented its functionality in `popup.js`, allowing users to clear the cached professor data with a single click. The background script handles the cache clearing and responds to the popup. [[1]](diffhunk://#diff-c4603180762496692401b6b6427dce242cb80aea2a8744967258c5d009e21848R72-R85) [[2]](diffhunk://#diff-ba1d79117eac8db74dc3200b08d9b080867e260408e9a2d73efaf69e327b0d00R1-R22) [[3]](diffhunk://#diff-21c11a7827ab60991878c0000f53381bb1ca1895488ae3b44a9b5255d5297b57R272-R285)

**Cache Management Improvements**
* Changed duration of cache duration and cleanup interval to 10 minutes.
* Simplified error handling in the background script by no longer caching failed professor lookups, and fixed the "cached" response flag for failures. [[1]](diffhunk://#diff-21c11a7827ab60991878c0000f53381bb1ca1895488ae3b44a9b5255d5297b57L226-R241) [[2]](diffhunk://#diff-21c11a7827ab60991878c0000f53381bb1ca1895488ae3b44a9b5255d5297b57L259-R255)

**Version Bump**
* Updated the extension version to `1.3.3` in `package.json`, `manifest.chrome.json`, and `manifest.firefox.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-c7c383bb167fe9220fe84b04e9c98420a22ba12ba9c8af68cd3ec492382eebfcL4-R4) [[3]](diffhunk://#diff-835b50967034394b01985a03ed1fdac713d8d088b86aa88974cf0e4037baf28aL4-R4)